### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bs4
+beautifulsoup4
 requests
 colorama
 argparse


### PR DESCRIPTION
Don't use [`bs4` dummy package](https://pypi.org/project/bs4/) as distributions don't ship it. They use `beautifulsoup4`.