### PR TITLE
Remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 bs4
 requests
 colorama
-argparse
 html5lib
 validators
 fake_useragent


### PR DESCRIPTION
`argparse` is a Python standard library.