### PR TITLE
Add poetry support

### DIFF
--- a/fdsploit.py
+++ b/fdsploit.py
@@ -17,7 +17,6 @@ from core.validations import *
 warnings.filterwarnings("ignore")
 
 # define some globals
-CUSTOM = False
 HOST, PORT = None, None
 USER_AGENT = 'FDsploit_{}_agent'.format(__version__)
 
@@ -103,10 +102,10 @@ def Fuzzer(url, verb, cookie, depth, payload, tchar, proxy, b64, uenc, keyword, 
     except KeyboardInterrupt:
         sys.exit(0)
 
-
-if __name__ == '__main__':
+def main():
     banner()
     args = console()
+    CUSTOM = False
     if args.url or args.file:
         if args.payload.startswith('/'): args.payload = args.payload[1:]
         if args.useragent: USER_AGENT = genUA()
@@ -141,4 +140,7 @@ if __name__ == '__main__':
         print("""usage: fdsploit.py [-u  | -f ] [-h] [-p] [-d] [-e {0,1,2}] [-t] [-b] [-x] [-c]
                    [-v] [--params  [...]] [-k] [-a] [--cmd]
                    [--lfishell {None,simple,expect,input}]""")
-#_EOF
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[tool.poetry]
+name = "fdsploit"
+version = "1.2"
+description = "File inclusion & directory traversal fuzzer/enumeration & exploitation framework"
+homepage = "https://github.com/chrispetrou/FDsploit"
+authors = ["Christophoros Petrou (game0ver)"]
+maintainers = ["Fabian Affolter <fabian@affolter-engineering.ch>"]
+license = "GPL-3.0-only"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Programming Language :: Python :: 3",
+]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+beautifulsoup4 = "^4.9"
+requests = {extras = ["security"], version = "^2.25"}
+colorama = "^0.4"
+html5lib = "^1.1"
+validators = "^0.18."
+fake_useragent = "^0.1.11"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+fdsploit = "fdsploit:main"
+
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Allow an installation of the code with `poetry install`. This will add `fdsploit` as executable to `$PATH` and enable distributions to ship packages in a simple way.